### PR TITLE
remove usage of RSpec.configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+## 2.0.3
+ - removed usage of RSpec.configure, see https://github.com/logstash-plugins/logstash-input-tcp/pull/21
+## 2.0.2
+ - refactored & cleaned up plugin structure, see https://github.com/logstash-plugins/logstash-input-tcp/pull/18
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-## 2.0.2
- - refactored & cleaned up plugin structure, see https://github.com/logstash-plugins/logstash-input-tcp/pull/18

--- a/logstash-input-tcp.gemspec
+++ b/logstash-input-tcp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-tcp'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over a TCP socket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -226,6 +226,7 @@ describe LogStash::Inputs::Tcp do
 
     let(:port) { rand(1024..65535) }
     subject { LogStash::Plugin.lookup("input", "tcp").new({ "port" => port }) }
+    let!(:helper) { TcpHelpers.new }
 
     after :each do
       subject.close rescue nil
@@ -244,7 +245,7 @@ describe LogStash::Inputs::Tcp do
       let(:events) do
         socket = Stud::try(5.times) { TCPSocket.new("127.0.0.1", port) }
 
-        result = pipelineless_input(subject, nevents) do
+        result = helper.pipelineless_input(subject, nevents) do
           nevents.times do |i|
             socket.puts("msg #{i}")
             socket.flush

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "logstash/devutils/rspec/spec_helper"
 
 # this has been taken from the udp input, it should be DRYed
 
-module TcpHelpers
+class TcpHelpers
 
   def pipelineless_input(plugin, size, &block)
     queue = Queue.new
@@ -12,16 +12,11 @@ module TcpHelpers
     end
     block.call
     sleep 0.1 while queue.size != size
-    result = nevents.times.inject([]) do |acc|
+    result = size.times.inject([]) do |acc|
       acc << queue.pop
     end
     plugin.do_stop
     input_thread.join
     result
   end
-
-end
-
-RSpec.configure do |c|
-  c.include TcpHelpers
 end


### PR DESCRIPTION
fixes #20 

also fixed a potential bug, using `nevent` in the spec helper `TcpHelpers` class. It **was** working because `nevent` was defined in the scope, but if another local var was used it would have failed.