### PR TITLE
Fix for issue #23

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -157,6 +157,10 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
     @logger.debug? && @logger.debug("Connection closed", :client => socket.peer)
   rescue Errno::ECONNRESET
     @logger.debug? && @logger.debug("Connection reset by peer", :client => socket.peer)
+  rescue OpenSSL::SSL::SSLError => e
+    # Fixes issue #23
+    @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)
+    socket.close rescue nil
   rescue => e
     # if plugin is stopping, don't bother logging it as an error
     !stop? && @logger.error("An error occurred. Closing connection", :client => socket.peer, :exception => e, :backtrace => e.backtrace)

--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -158,7 +158,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
   rescue Errno::ECONNRESET
     @logger.debug? && @logger.debug("Connection reset by peer", :client => socket.peer)
   rescue OpenSSL::SSL::SSLError => e
-    # Fixes issue #23
+    # Fixes issue #23 
     @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)
     socket.close rescue nil
   rescue => e

--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -158,7 +158,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
   rescue Errno::ECONNRESET
     @logger.debug? && @logger.debug("Connection reset by peer", :client => socket.peer)
   rescue OpenSSL::SSL::SSLError => e
-    # Fixes issue #23 
+    # Fixes issue #23
     @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)
     socket.close rescue nil
   rescue => e


### PR DESCRIPTION
Successfully tested.  Prints out an exception in Logstash, but doesn't cause a crash anymore.  Exception example:

    SSL Error {:exception=>#<OpenSSL::SSL::SSLError: Unrecognized SSL message, plaintext connection?>, :backtrace=>["org/jruby/ext/openssl/SSLSocket.java:262:in `accept'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/jruby-openssl-0.9.12-java/lib/jopenssl19/openssl/ssl-internal.rb:106:in `accept'", "/opt/logstash/vendor/local_gems/973ddac3/logstash-input-tcp-2.0.5.pre.a/lib/logstash/inputs/tcp.rb:108:in `run_server'", "/opt/logstash/vendor/local_gems/973ddac3/logstash-input-tcp-2.0.5.pre.a/lib/logstash/inputs/tcp.rb:80:in `run'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-2.0.0-java/lib/logstash/pipeline.rb:180:in `inputworker'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-2.0.0-java/lib/logstash/pipeline.rb:174:in `start_input'"], :level=>:error}

No document or `message` is captured if an SSLError exception is caught (desired result).