### PR TITLE
Added IOError catch to handle_socket()

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -162,6 +162,9 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
     @logger.debug? && @logger.debug("Connection closed", :client => socket.peer)
   rescue Errno::ECONNRESET
     @logger.debug? && @logger.debug("Connection reset by peer", :client => socket.peer)
+  rescue IOError => e
+    # Catch IOError: closed stream
+    @logger.error("IO Error", :exception => e, :backtrace => e.backtrace)
   rescue OpenSSL::SSL::SSLError => e
     # Fixes issue #23
     @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)


### PR DESCRIPTION
Added IOError catch in handle_socket() to prevent logstash from exiting prematurely.

Please see https://github.com/logstash-plugins/logstash-input-tcp/issues/23

lib/logstash/inputs/tcp.rb
    @logger.debug? && @logger.debug("Connection closed", :client => socket.peer)
   rescue Errno::ECONNRESET
     @logger.debug? && @logger.debug("Connection reset by peer", :client => socket.peer)
+  rescue IOError => e
+    # Catch IOError: closed stream
+    @logger.error("IO Error", :exception => e, :backtrace => e.backtrace)
   rescue OpenSSL::SSL::SSLError => e
     # Fixes issue #23
     @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)