### PR TITLE
properly convert sslsubject to string & specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 3.0.1
+ - properly convert sslsubject to string before assigning to event field, added specs, see https://github.com/logstash-plugins/logstash-input-tcp/pull/38
+
 ## 3.0.0
- - Deprecate ssl_cacert as it's confusing, does it job but when willing to add a chain of certificated the name and behaviour is a bit confusing. 
+ - Deprecate ssl_cacert as it's confusing, does it job but when willing to add a chain of certificated the name and behaviour is a bit confusing.
  - Add ssl_extra_chain_certs that allows you to specify a list of certificates path that will be added to the CAStore.
  - Make ssl_verify=true as a default value, if using ssl and performing validation is not reasonable as security might be compromised.
  - Add tests to verify behaviour under different SSL connection circumstances.

--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -153,7 +153,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
       codec.decode(read(socket)) do |event|
         event["host"] ||= client_address
         event["port"] ||= client_port
-        event["sslsubject"] ||= socket.peer_cert.subject if @ssl_enable && @ssl_verify
+        event["sslsubject"] ||= socket.peer_cert.subject.to_s if @ssl_enable && @ssl_verify
         decorate(event)
         output_queue << event
       end
@@ -176,7 +176,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
     codec.respond_to?(:flush) && codec.flush do |event|
       event["host"] ||= client_address
       event["port"] ||= client_port
-      event["sslsubject"] ||= socket.peer_cert.subject if @ssl_enable && @ssl_verify
+      event["sslsubject"] ||= socket.peer_cert.subject.to_s if @ssl_enable && @ssl_verify
       decorate(event)
       output_queue << event
     end

--- a/logstash-input-tcp.gemspec
+++ b/logstash-input-tcp.gemspec
@@ -1,17 +1,16 @@
 Gem::Specification.new do |s|
-
-  s.name            = 'logstash-input-tcp'
-  s.version         = '3.0.0'
-  s.licenses        = ['Apache License (2.0)']
-  s.summary         = "Read events over a TCP socket."
-  s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors         = ["Elastic"]
-  s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.name          = 'logstash-input-tcp'
+  s.version       = '3.0.1'
+  s.licenses      = ['Apache License (2.0)']
+  s.summary       = "Read events over a TCP socket."
+  s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.authors       = ["Elastic"]
+  s.email         = 'info@elastic.co'
+  s.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*', 'spec/**/*', '*.gemspec', '*.md', 'CONTRIBUTORS', 'Gemfile', 'LICENSE', 'NOTICE.TXT', 'CHANGELOG.md', 'README.md']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -31,4 +30,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'flores', '~> 0.0.6'
   s.add_development_dependency 'stud', '~> 0.0.22'
 end
-

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -124,7 +124,7 @@ describe LogStash::Inputs::Tcp do
   end
 
   it "should read events with json codec (testing 'host' handling)" do
-    port = 5514
+    port = 5517
     conf = <<-CONFIG
       input {
         tcp {


### PR DESCRIPTION
the `Event["sslsubject"]` field was assigned the `OpenSSL::X509::Name` object - `to_s` need to be called on it to assign the `OpenSSL::X509::Name` string representation in the `Event`. 

The problem surfaced when using the logstash-core-event-java where the types of objects assignable to Event fields is stricter. 

I also added specs for this and did some cosmetic cleanups. 