### PR TITLE
Improving tls stability

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -115,7 +115,6 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
       rescue OpenSSL::SSL::SSLError => e
         # log error, close socket, accept next connection
         @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)
-        socket.close rescue nil
       rescue => e
         # if this exception occured while the plugin is stopping
         # just ignore and exit


### PR DESCRIPTION
This fixes two bugs in the TCP input.

1) When an error occurs in accepting a new socket, common with TLS scenarios, the _previous_ connection accepted would accidentally be closed. Oops!

2) When providing logging during an exception, we were trying to log the socket's peer address. However, asking a socket for it's peer address _after_ the socket has been closed will cause an exception, so our exception handler was throwing an exception when we tried to log. Oops!

I've added some additional tests to help cover certain kinds of scenarios.

I wanted to write a regression test to verify that the two above scenarios no longer occurred, but I am not sure of the complexity yet to write such a test (with multiple active connections, injecting one or two bad/corrupt connections and verifying the result). Since I don't want to delay the merging or review of this change, I'll submit now. I have manually verified that Logstash doesn't crash under the two above scenarios and it behaves, what I believe to be, correctly (the bad connection is dropped and existing connections are unharmed).