### PR TITLE
Change log level for OpenSSL error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
+## 4.0.2
+ - Change the log level of the SSLError for the handshake from **error** to **debug** https://github.com/logstash-plugins/logstash-input-tcp/pull/53
 ## 4.0.1
-  - Republish all the gems under jruby.
+ - Republish all the gems under jruby.
 ## 4.0.0
-  - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
+ - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
 # 3.0.5
  - Fixed a bug where using a certificate with a passphrase wouldn't work.
 # 3.0.4
-  - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
+ - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 3.0.3
-  - New dependency requirements for logstash-core for the 5.0 release
+ - New dependency requirements for logstash-core for the 5.0 release
 ## 3.0.2
-- Fixed a bug where previous connection would accidentally be closed when accepting new socket connection
-- Fixed an issue with log message which used a closed socket's peer address 
+ - Fixed a bug where previous connection would accidentally be closed when accepting new socket connection
+ - Fixed an issue with log message which used a closed socket's peer address 
 
 ## 3.0.1
  - properly convert sslsubject to string before assigning to event field, added specs, see https://github.com/logstash-plugins/logstash-input-tcp/pull/38

--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -118,7 +118,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
         server_connection_thread(output_queue, socket)
       rescue OpenSSL::SSL::SSLError => e
         # log error, close socket, accept next connection
-        @logger.error("SSL Error", :exception => e, :backtrace => e.backtrace)
+        @logger.debug? && @logger.debug("SSL Error", :exception => e, :backtrace => e.backtrace)
       rescue => e
         # if this exception occured while the plugin is stopping
         # just ignore and exit

--- a/logstash-input-tcp.gemspec
+++ b/logstash-input-tcp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-tcp'
-  s.version         = '4.0.1'
+  s.version         = '4.0.2'
   s.licenses      = ['Apache License (2.0)']
   s.summary       = "Read events over a TCP socket."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
SSL Error can happen when a handshake is not correctly completed like
when a LB is in front of the tcp input and does keep alive to check if
the port is still up and running. We should not mark them as error but
instead as debug.