### PR TITLE
Change loading ca-bundle logic

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -218,8 +218,8 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
       @ssl_context = OpenSSL::SSL::SSLContext.new
       @ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@ssl_cert))
       @ssl_context.key = OpenSSL::PKey::RSA.new(File.read(@ssl_key),@ssl_key_passphrase.value)
+      @ssl_context.cert_store  = load_cert_store
       if @ssl_verify
-        @ssl_context.cert_store  = load_cert_store
         @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
       end
     rescue => e


### PR DESCRIPTION
Hi!

Several months ago I came across an issue. Let's assume this is my configuration:

```
input {
    tcp {
        port => 9000
        type => syslog
        ssl_enable => true
        ssl_cert => '${SOME_CRT}'
        ssl_key => '${SOME_KEY}'
        ssl_extra_chain_certs => ['${SOME_CA_BUNDLE}']
        ssl_verify => false
    }
}
```

If my certificate is actually signed by a real certificate authority, then I have to provide the entire CA-bundle in order for the cert to match the key. However, if I do not want my certificate to be actually verified in peer mode (I'm debugging, and using a server with a different hostname), if I disable such verification, then it essentially the same as if I did not even provide `ssl_extra_chain_certs` argument. 

My pull request fixes this logic. So in case you have to provide a ca-bundle separately from your cert file and disable `ssl_verify`, you now can.
