### PR TITLE
Make this input plugin capable of doing line delimiting.

### DIFF
--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -15,21 +15,21 @@ require_relative "../spec_helper"
 #Cabin::Channel.get(LogStash).level = :debug
 describe LogStash::Inputs::Tcp do
 
-  context "codec (PR #1372)" do
-    it "switches from plain to line" do
+  context "codec correction" do
+    it "switches from line to plain" do
       require "logstash/codecs/plain"
       require "logstash/codecs/line"
-      plugin = LogStash::Inputs::Tcp.new("codec" => LogStash::Codecs::Plain.new, "port" => 0)
+      plugin = LogStash::Inputs::Tcp.new("codec" => LogStash::Codecs::Line.new, "port" => 0)
       plugin.register
-      insist { plugin.codec }.is_a?(LogStash::Codecs::Line)
+      insist { plugin.codec }.is_a?(LogStash::Codecs::Plain)
       plugin.close
     end
-    it "switches from json to json_lines" do
+    it "switches from json_lines to json" do
       require "logstash/codecs/json"
       require "logstash/codecs/json_lines"
-      plugin = LogStash::Inputs::Tcp.new("codec" => LogStash::Codecs::JSON.new, "port" => 0)
+      plugin = LogStash::Inputs::Tcp.new("codec" => LogStash::Codecs::JSONLines.new, "port" => 0)
       plugin.register
-      insist { plugin.codec }.is_a?(LogStash::Codecs::JSONLines)
+      insist { plugin.codec }.is_a?(LogStash::Codecs::JSON)
       plugin.close
     end
   end


### PR DESCRIPTION
This change keeps the behavior the same, but inverts the previous
implementation which used `fix_streaming_codecs` to automatically
switch from `plain` to `lines` and from `json` to `json_lines`. The
switch was needed because the input wasn't programmed to make
choices about line delimiters -- that job was handled by the `line` and
`json_line` codec.

This particular change was driven by a discussion about improving the
`cef` codec and how I personally didn't want to have both a `cef` and
`cef_lines` codec.

I've had discussions over the past year or two with folks on the
Logstash team where we talked about separating "payload delimiting"
concerns away from the codecs and moving that delimiting functionality
into a new system we tentatively called a "Mill" (credit to @guyboertje
for the term and I think the original idea) after the idea of a sawmill
which cuts raw material (logs) into usable pieces (lumber).

This commit doesn't introduce "mill" as a named concept, but implements
the idea that codecs are probably not the best place for delimiting to
happen. You can feel the weirdness of some codecs doing delimiting in
several places:

* The file input (files are a stream of bytes) emitting *lines* to its codecs.
* The tcp input emitting *bytes* to its codecs
* The fact that `json` and `json_lines` codecs exist and do the same
thing except one does line delimiting also.
* The fact that `plain` and `line` codecs exist and do the same thing
except one does line delimiting also.
* The `fix_streaming_codecs` method that hacks around the previous two
points to force (previously) the `line` codec to be used on the tcp
input if the user mistakenly configured `plain`. Same for JSON.
