### PR TITLE
Metadata typo.

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -106,7 +106,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
   config :ssl_extra_chain_certs, :validate => :array, :default => []
 
   HOST_FIELD = "host".freeze
-  HOST_IP_FIELD = "[@metdata][ip_address]".freeze
+  HOST_IP_FIELD = "[@metadata][ip_address]".freeze
   PORT_FIELD = "port".freeze
   PROXY_HOST_FIELD = "proxy_host".freeze
   PROXY_PORT_FIELD = "proxy_port".freeze

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -76,7 +76,7 @@ describe LogStash::Inputs::Tcp do
       event = events[i]
       insist { event.get("message") } == "#{i} ☹"
       insist { event.get("host") } == host
-      insist { event.get("[@metdata][ip_address]") } == '127.0.0.1'
+      insist { event.get("[@metadata][ip_address]") } == '127.0.0.1'
     end
   end
 


### PR DESCRIPTION
After upgrade from 5.6.4 to logstash 6.0.1 

`"@metdata":{"ip_address":"127.0.0.1"}`

field appeared in our elasticsearch documents.