### PR TITLE
Add hostname 'ip6-localhost' to list of accepted hostnames for unit test

### DIFF
--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -75,7 +75,7 @@ describe LogStash::Inputs::Tcp do
     event_count.times do |i|
       event = events[i]
       insist { event.get("message") } == "#{i} ☹"
-      insist { event.get("host") } == host
+      insist { ["localhost","ip6-localhost"].includes? event.get("host") }
       insist { event.get("[@metadata][ip_address]") } == '127.0.0.1'
     end
   end


### PR DESCRIPTION
Apparently, Travis-CI reports "ip6-localhost" rather than "localhost" while running tests.

Fixes #97
