### PR TITLE
Port server-mode SSL to Netty.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
   compile 'io.netty:netty-all:4.1.18.Final'
   compile 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
   compile group: 'commons-io', name: 'commons-io', version: '2.5'
+  compile 'org.apache.logging.log4j:log4j-core:2.9.1'
 }
 
 task vendor(dependsOn: shadowJar) << {

--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -11,6 +11,7 @@ require "socket"
 require "openssl"
 
 java_import org.logstash.tcp.InputLoop
+java_import org.logstash.tcp.SslOptions
 
 # Read events over a TCP socket.
 #
@@ -137,22 +138,24 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
 
     @logger.info("Starting tcp input listener", :address => "#{@host}:#{@port}", :ssl_enable => "#{@ssl_enable}")
     if server?
-      if @ssl_enable
-        self.server_socket = new_server_socket
-      else
-        @loop = InputLoop.new(@host, @port, DecoderImpl.new(@codec, self))
-      end
+      ssl_options = SslOptions.builder
+        .set_is_ssl_enabled(@ssl_enable)
+        .set_should_verify(@ssl_verify)
+        .set_ssl_cert(@ssl_cert)
+        .set_ssl_key(@ssl_key)
+        .set_ssl_key_passphrase(@ssl_key_passphrase.value)
+        .set_ssl_extra_chain_certs(@ssl_extra_chain_certs.to_java(:string))
+        .build
+
+      @loop = InputLoop.new(@host, @port, DecoderImpl.new(@codec, self), ssl_options,
+                            @logger.to_java(org.apache.logging.log4j.Logger))
     end
   end
 
   def run(output_queue)
     @output_queue = output_queue
     if server?
-      if @ssl_enable
-        run_ssl_server
-      else
-        @loop.run
-      end
+      @loop.run
     else
       run_client()
     end
@@ -196,30 +199,6 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
 
   private
 
-  RUN_LOOP_ERROR_MESSAGE="TCP input server encountered error"
-  def run_ssl_server()
-    while !stop?
-      begin
-        socket = add_connection_socket(server_socket.accept)
-        # start a new thread for each connection.
-        server_connection_thread(socket)
-      rescue OpenSSL::SSL::SSLError => e
-        # log error, close socket, accept next connection
-        @logger.debug? && @logger.debug("SSL Error", :exception => e, :backtrace => e.backtrace)
-      rescue => e
-        @logger.error(
-          RUN_LOOP_ERROR_MESSAGE, 
-          :message => e.message,
-          :class => e.class.name,
-          :backtrace => e.backtrace
-        )
-      end
-    end
-  ensure
-    # catch all rescue nil on close to discard any close errors or invalid socket
-    server_socket.close rescue nil
-  end
-
   def run_client()
     while !stop?
       self.client_socket = new_client_socket
@@ -228,17 +207,6 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
   ensure
     # catch all rescue nil on close to discard any close errors or invalid socket
     client_socket.close rescue nil
-  end
-
-  def server_connection_thread(socket)
-    Thread.new(socket) do |s|
-      begin
-        @logger.debug? && @logger.debug("Accepted connection", :client => s.peer, :server => "#{@host}:#{@port}")
-        handle_socket(s)
-      ensure
-        delete_connection_socket(s)
-      end
-    end
   end
 
   def handle_socket(socket)
@@ -325,17 +293,6 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
       cert_store.add_file(cert)
     end
     cert_store
-  end
-
-  def new_server_socket
-    begin
-      socket = TCPServer.new(@host, @port)
-    rescue Errno::EADDRINUSE
-      @logger.error("Could not start TCP server: Address in use", :host => @host, :port => @port)
-      raise
-    end
-
-    @ssl_enable ? OpenSSL::SSL::SSLServer.new(socket, ssl_context) : socket
   end
 
   def new_client_socket

--- a/src/main/java/org/logstash/tcp/SslOptions.java
+++ b/src/main/java/org/logstash/tcp/SslOptions.java
@@ -1,0 +1,124 @@
+package org.logstash.tcp;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+public class SslOptions {
+
+    private final boolean isSslEnabled;
+    private final boolean shouldVerify;
+    private final String sslCert;
+    private final String sslKey;
+    private final String sslKeyPassphrase;
+    private final String[] sslExtraChainCerts;
+
+    private SslOptions(SslOptionsBuilder builder) {
+        this.isSslEnabled = builder.isSslEnabled;
+        this.shouldVerify = builder.shouldVerify;
+        this.sslCert = builder.sslCert;
+        this.sslKey = builder.sslKey;
+        this.sslKeyPassphrase = builder.sslKeyPassphrase;
+        this.sslExtraChainCerts = builder.sslExtraChainCerts;
+    }
+
+    public boolean isSslEnabled() {
+        return isSslEnabled;
+    }
+
+    public boolean isShouldVerify() {
+        return shouldVerify;
+    }
+
+    public String getSslCert() {
+        return sslCert;
+    }
+
+    public String getSslKey() {
+        return sslKey;
+    }
+
+    public String getSslKeyPassphrase() {
+        return sslKeyPassphrase;
+    }
+
+    public String[] getSslExtraChainCerts() {
+        return sslExtraChainCerts;
+    }
+
+    public static SslOptionsBuilder builder() {
+        return new SslOptionsBuilder();
+    }
+
+    public SslContext toSslContext() throws Exception {
+        if (!isSslEnabled) {
+            return null;
+        }
+
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(
+                new File(getSslCert()), new File(getSslKey()), getSslKeyPassphrase());
+
+        if (getSslExtraChainCerts().length > 0) {
+            X509Certificate[] certChain = new X509Certificate[getSslExtraChainCerts().length];
+            for (int k = 0; k < getSslExtraChainCerts().length; k++) {
+                try (InputStream inStream = new FileInputStream(getSslExtraChainCerts()[k])) {
+                    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                    certChain[k] = (X509Certificate) cf.generateCertificate(inStream);
+                }
+            }
+            sslContextBuilder = sslContextBuilder.trustManager(certChain);
+        }
+        sslContextBuilder.clientAuth(isShouldVerify() ? ClientAuth.REQUIRE : ClientAuth.NONE);
+        return sslContextBuilder.build();
+    }
+
+    public static final class SslOptionsBuilder {
+        private boolean isSslEnabled = false;
+        private boolean shouldVerify = true;
+        private String sslCert;
+        private String sslKey;
+        private String sslKeyPassphrase;
+        private String[] sslExtraChainCerts;
+
+        public SslOptionsBuilder setIsSslEnabled(boolean isSslEnabled) {
+            this.isSslEnabled = isSslEnabled;
+            return this;
+        }
+
+        public SslOptionsBuilder setShouldVerify(boolean shouldVerify) {
+            this.shouldVerify = shouldVerify;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslCert(String sslCert) {
+            this.sslCert = sslCert;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslKey(String sslKey) {
+            this.sslKey = sslKey;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslKeyPassphrase(String sslKeyPassphrase) {
+            this.sslKeyPassphrase = sslKeyPassphrase;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslExtraChainCerts(String[] sslExtraChainCerts) {
+            this.sslExtraChainCerts = sslExtraChainCerts;
+            return this;
+        }
+
+        public SslOptions build() {
+            return new SslOptions(this);
+        }
+    }
+
+}


### PR DESCRIPTION
The `SslOptions.toSslContext()` method accommodates all the SSL options from the Ruby implementation. Some simple perf tests with the [tcpkali](https://github.com/satori-com/tcpkali) tool showed that the Netty SSL implementation ranged from roughly equal to ~30% faster than the Ruby SSL implementation depending on the test setup. In general, the performance of the Netty implementation exceeded the Ruby implementation when the number of TCP clients exceeded ~500.

After talking with @jordansissel and @jsvd, I removed two integration tests for the previous Ruby SSL implementation for the following reasons:

* The "should log the error on accept" test was removed because the logger that now logs this error is in Java and no longer easily accessible via rspec. The presence of this log message was verified via manual testing.

* The "connection was healthy but now has garbage or corruption" test was removed partly because its success criteria was based on the threading model of the Ruby SSL implementation and partly because it's testing core SSL behavior which should be covered by Netty itself.

Fixes #104.
