### PR TITLE
Since the IP-address it metadata so should port

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -107,7 +107,7 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
 
   HOST_FIELD = "host".freeze
   HOST_IP_FIELD = "[@metadata][ip_address]".freeze
-  PORT_FIELD = "port".freeze
+  PORT_FIELD = "[@metadata][port]".freeze
   PROXY_HOST_FIELD = "proxy_host".freeze
   PROXY_PORT_FIELD = "proxy_port".freeze
   SSLSUBJECT_FIELD = "sslsubject".freeze

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -111,7 +111,7 @@ describe LogStash::Inputs::Tcp do
     event_count.times do |i|
       insist { events[i].get("message") } == "#{i} ☹"
       insist { events[i].get("host") } == "1.2.3.4"
-      insist { events[i].get("port") } == "1234"
+      insist { events[i].get("[@metadata][port]") } == "1234"
       insist { events[i].get("proxy_host") } == "5.6.7.8"
       insist { events[i].get("proxy_port") } == "5678"
     end


### PR DESCRIPTION
No need to really put the port number into the event. It can be useful
but as metadata.