### PR TITLE
reorder shut down of the two event loops to prevent shutdown exceptions

### DIFF
--- a/src/main/java/org/logstash/tcp/InputLoop.java
+++ b/src/main/java/org/logstash/tcp/InputLoop.java
@@ -63,8 +63,11 @@ public final class InputLoop implements Runnable, Closeable {
     @Override
     public void close() {
         try {
-            worker.shutdownGracefully().sync();
+            // Shut down boss first otherwise new connections
+            // will be passed to a closed worker loop, triggering:
+            // RejectedExecutionException: event executor terminated
             boss.shutdownGracefully().sync();
+            worker.shutdownGracefully().sync();
         } catch (final InterruptedException ex) {
             throw new IllegalStateException(ex);
         }


### PR DESCRIPTION
fixes https://github.com/logstash-plugins/logstash-input-tcp/issues/110