### PR TITLE
Port ssl on server mode to netty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 ---
 sudo: false
-language: ruby
-cache: bundler
-matrix:
-  include:
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.x
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.0
-  - rvm: jruby-1.7.27
-    env: LOGSTASH_BRANCH=5.6
-  fast_finish: true
-install: true
+env:
+  - LOGSTASH_VERSION=6.4.0
+  - LOGSTASH_VERSION=5.6.11
+  - LOGSTASH_VERSION=7.0.0-alpha1-SNAPSHOT
+install: ci/setup.sh
 script: ci/build.sh
 jdk: oraclejdk8

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
+
+if RUBY_VERSION == "1.9.3"
+  gem 'rake', '12.2.1'
+end

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
   compile 'io.netty:netty-all:4.1.18.Final'
   compile 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
   compile group: 'commons-io', name: 'commons-io', version: '2.5'
+  compile 'org.apache.logging.log4j:log4j-core:2.9.1'
 }
 
 task vendor(dependsOn: shadowJar) << {

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
-# version: 1
-########################################################
-#
-# AUTOMATICALLY GENERATED! DO NOT EDIT
-#
-########################################################
 set -e
 
-echo "Starting build process in: `pwd`"
-source ./ci/setup.sh
+export LOGSTASH_PATH=$PWD/logstash-${LOGSTASH_VERSION}
+export PATH=$LOGSTASH_PATH/vendor/jruby/bin:$LOGSTASH_PATH/vendor/bundle/jruby/1.9.3/bin:$LOGSTASH_PATH/vendor/bundle/jruby/2.3.0/bin:$PATH
+export LOGSTASH_SOURCE=1
 
-if [[ -f "ci/run.sh" ]]; then
-    echo "Running custom build script in: `pwd`/ci/run.sh"
-    source ./ci/run.sh
-else
-    echo "Running default build scripts in: `pwd`/ci/build.sh"
-    bundle install
-    bundle exec rake vendor
-    bundle exec rspec spec
-fi
+jruby -S bundle exec rspec

--- a/lib/logstash/inputs/tcp/compat_ssl_options.rb
+++ b/lib/logstash/inputs/tcp/compat_ssl_options.rb
@@ -1,0 +1,83 @@
+require 'openssl'
+
+java_import 'io.netty.handler.ssl.ClientAuth'
+java_import 'io.netty.handler.ssl.SslContextBuilder'
+java_import 'java.io.FileInputStream'
+java_import 'java.io.FileReader'
+java_import 'java.security.cert.CertificateFactory'
+java_import 'org.bouncycastle.openssl.PEMParser'
+java_import 'org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter'
+java_import 'java.security.cert.X509Certificate'
+
+# API to simulate:
+#
+#     ssl_context = SslOptions.builder
+#       .set_is_ssl_enabled(@ssl_enable)
+#       .set_should_verify(@ssl_verify)
+#       .set_ssl_cert(@ssl_cert)
+#       .set_ssl_key(@ssl_key)
+#       .set_ssl_key_passphrase(@ssl_key_passphrase.value)
+#       .set_ssl_extra_chain_certs(@ssl_extra_chain_certs.to_java(:string))
+#       .build.toSslContext()
+class CompatSslOptions
+  def self.builder
+    new
+  end
+
+  def set_is_ssl_enabled(boolean)
+    @ssl_enabled = boolean
+    self
+  end
+
+  def set_should_verify(boolean)
+    @ssl_verify = boolean
+    self
+  end
+
+  def set_ssl_cert(path)
+    @ssl_cert_path = path
+    self
+  end
+
+  def set_ssl_key(path)
+    @ssl_key_path = path
+    self
+  end
+
+  def set_ssl_key_passphrase(passphrase)
+    @ssl_key_passphrase = passphrase
+    self
+  end
+
+  def set_ssl_extra_chain_certs(certs)
+    @ssl_extra_chain_certs = certs
+    self
+  end
+
+  def build; self; end
+
+  def toSslContext
+    return nil unless @ssl_enabled
+
+    # create certificate object
+    cf = CertificateFactory.getInstance("X.509")
+    cer = cf.generateCertificate(FileInputStream.new(@ssl_cert_path))
+
+    # convert key from pkcs1 to pkcs8 and get PrivateKey object
+    pem_parser = PEMParser.new(FileReader.new(@ssl_key_path))
+    obj = pem_parser.read_object
+    kp = JcaPEMKeyConverter.new.get_key_pair(obj)
+    private_key = kp.private
+
+    sslContextBuilder = SslContextBuilder.forServer(private_key, @ssl_key_passphrase, cer)
+
+    if (@ssl_extra_chain_certs.size > 0)
+      cert_chain = @ssl_extra_chain_certs.map do |cert|
+        cf.generateCertificate(FileInputStream.new(cert))
+      end
+      sslContextBuilder = sslContextBuilder.trustManager(cert_chain.to_java(java.security.cert.X509Certificate))
+    end
+    sslContextBuilder.clientAuth(@ssl_verify ? ClientAuth::REQUIRE : ClientAuth::NONE)
+    sslContextBuilder.build()
+  end
+end

--- a/src/main/java/org/logstash/tcp/InputLoop.java
+++ b/src/main/java/org/logstash/tcp/InputLoop.java
@@ -56,22 +56,10 @@ public final class InputLoop implements Runnable, Closeable {
      * @param keepAlive set to true to instruct the socket to issue TCP keep alive
      */
     public InputLoop(final String host, final int port, final Decoder decoder, final boolean keepAlive,
-                     final SslOptions sslOptions, final Logger logger) {
-
-        // construct the SslContext now in order to validate the SSL options at startup rather
-        // than client connection time
-        if (sslOptions != null && sslOptions.isSslEnabled()) {
-            try {
-                sslContext = sslOptions.toSslContext();
-            } catch (Exception e) {
-                throw new RuntimeException("Error validating SSL configuration: " +
-                        e.getMessage(), e);
-            }
-        } else {
-            sslContext = null;
-        }
+                     final SslContext sslContext, final Logger logger) {
 
         this.logger = logger;
+        this.sslContext = sslContext;
         worker = new NioEventLoopGroup();
         boss = new NioEventLoopGroup(1);
         future = new ServerBootstrap().group(boss, worker)

--- a/src/main/java/org/logstash/tcp/InputLoop.java
+++ b/src/main/java/org/logstash/tcp/InputLoop.java
@@ -11,8 +11,10 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.logging.log4j.Logger;
 
 import java.io.Closeable;
 
@@ -37,20 +39,46 @@ public final class InputLoop implements Runnable, Closeable {
     private final ChannelFuture future;
 
     /**
+     * Reference to the logger.
+     */
+    private final Logger logger;
+
+    /**
+     * SSL configuration.
+     */
+    private final SslContext sslContext;
+
+    /**
      * Ctor.
      * @param host Host to bind the listen to
      * @param port Port to listen on
      * @param decoder {@link Decoder} provided by Jruby
      * @param keepAlive set to true to instruct the socket to issue TCP keep alive
      */
-    public InputLoop(final String host, final int port, final Decoder decoder, final boolean keepAlive) {
+    public InputLoop(final String host, final int port, final Decoder decoder, final boolean keepAlive,
+                     final SslOptions sslOptions, final Logger logger) {
+
+        // construct the SslContext now in order to validate the SSL options at startup rather
+        // than client connection time
+        if (sslOptions != null && sslOptions.isSslEnabled()) {
+            try {
+                sslContext = sslOptions.toSslContext();
+            } catch (Exception e) {
+                throw new RuntimeException("Error validating SSL configuration: " +
+                        e.getMessage(), e);
+            }
+        } else {
+            sslContext = null;
+        }
+
+        this.logger = logger;
         worker = new NioEventLoopGroup();
         boss = new NioEventLoopGroup(1);
         future = new ServerBootstrap().group(boss, worker)
             .channel(NioServerSocketChannel.class)
             .option(ChannelOption.SO_BACKLOG, 1024)
             .childOption(ChannelOption.SO_KEEPALIVE, keepAlive)
-            .childHandler(new InputLoop.InputHandler(decoder)).bind(host, port);
+            .childHandler(new InputLoop.InputHandler(decoder, sslContext, logger)).bind(host, port);
     }
 
     @Override
@@ -87,18 +115,42 @@ public final class InputLoop implements Runnable, Closeable {
         private final Decoder decoder;
 
         /**
+         * SSL configuration options.
+         */
+        private final SslContext sslContext;
+
+        /**
+         * Reference to the logger.
+         */
+        private final Logger logger;
+
+        /**
          * Ctor.
          * @param decoder {@link Decoder} provided by JRuby.
          */
-        InputHandler(final Decoder decoder) {
+        InputHandler(final Decoder decoder, final SslContext sslContext, Logger logger) {
             this.decoder = decoder;
+            this.sslContext = sslContext;
+            this.logger = logger;
         }
 
         @Override
         protected void initChannel(final SocketChannel channel) throws Exception {
             Decoder localCopy = decoder.copy();
-            channel.pipeline().addLast(new InputLoop.InputHandler.DecoderAdapter(localCopy));
+
+            // if SSL is enabled, the SSL handler must be added to the pipeline first
+            if (sslContext != null) {
+                channel.pipeline().addLast(sslContext.newHandler(channel.alloc()));
+            }
+
+            channel.pipeline().addLast(new DecoderAdapter(localCopy, logger));
             channel.closeFuture().addListener(new FlushOnCloseListener(localCopy));
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            logger.error("Error in Netty input handler: " + cause);
+            super.exceptionCaught(ctx, cause);
         }
 
         /**
@@ -134,10 +186,16 @@ public final class InputLoop implements Runnable, Closeable {
             private final Decoder decoder;
 
             /**
+             * Reference to the logger.
+             */
+            private final Logger logger;
+
+            /**
              * Ctor.
              * @param decoder {@link Decoder} provided by JRuby.
              */
-            DecoderAdapter(final Decoder decoder) {
+            DecoderAdapter(final Decoder decoder, Logger logger) {
+                this.logger = logger;
                 this.decoder = decoder;
             }
 
@@ -147,8 +205,8 @@ public final class InputLoop implements Runnable, Closeable {
             }
 
             @Override
-            public void exceptionCaught(final ChannelHandlerContext ctx,
-                final Throwable cause) {
+            public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
+                logger.error("Error in Netty pipeline: " + cause);
                 ctx.close();
             }
         }

--- a/src/main/java/org/logstash/tcp/SslOptions.java
+++ b/src/main/java/org/logstash/tcp/SslOptions.java
@@ -1,0 +1,124 @@
+package org.logstash.tcp;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+public class SslOptions {
+
+    private final boolean isSslEnabled;
+    private final boolean shouldVerify;
+    private final String sslCert;
+    private final String sslKey;
+    private final String sslKeyPassphrase;
+    private final String[] sslExtraChainCerts;
+
+    private SslOptions(SslOptionsBuilder builder) {
+        this.isSslEnabled = builder.isSslEnabled;
+        this.shouldVerify = builder.shouldVerify;
+        this.sslCert = builder.sslCert;
+        this.sslKey = builder.sslKey;
+        this.sslKeyPassphrase = builder.sslKeyPassphrase;
+        this.sslExtraChainCerts = builder.sslExtraChainCerts;
+    }
+
+    public boolean isSslEnabled() {
+        return isSslEnabled;
+    }
+
+    public boolean isShouldVerify() {
+        return shouldVerify;
+    }
+
+    public String getSslCert() {
+        return sslCert;
+    }
+
+    public String getSslKey() {
+        return sslKey;
+    }
+
+    public String getSslKeyPassphrase() {
+        return sslKeyPassphrase;
+    }
+
+    public String[] getSslExtraChainCerts() {
+        return sslExtraChainCerts;
+    }
+
+    public static SslOptionsBuilder builder() {
+        return new SslOptionsBuilder();
+    }
+
+    public SslContext toSslContext() throws Exception {
+        if (!isSslEnabled) {
+            return null;
+        }
+
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(
+                new File(getSslCert()), new File(getSslKey()), getSslKeyPassphrase());
+
+        if (getSslExtraChainCerts().length > 0) {
+            X509Certificate[] certChain = new X509Certificate[getSslExtraChainCerts().length];
+            for (int k = 0; k < getSslExtraChainCerts().length; k++) {
+                try (InputStream inStream = new FileInputStream(getSslExtraChainCerts()[k])) {
+                    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                    certChain[k] = (X509Certificate) cf.generateCertificate(inStream);
+                }
+            }
+            sslContextBuilder = sslContextBuilder.trustManager(certChain);
+        }
+        sslContextBuilder.clientAuth(isShouldVerify() ? ClientAuth.REQUIRE : ClientAuth.NONE);
+        return sslContextBuilder.build();
+    }
+
+    public static final class SslOptionsBuilder {
+        private boolean isSslEnabled = false;
+        private boolean shouldVerify = true;
+        private String sslCert;
+        private String sslKey;
+        private String sslKeyPassphrase;
+        private String[] sslExtraChainCerts;
+
+        public SslOptionsBuilder setIsSslEnabled(boolean isSslEnabled) {
+            this.isSslEnabled = isSslEnabled;
+            return this;
+        }
+
+        public SslOptionsBuilder setShouldVerify(boolean shouldVerify) {
+            this.shouldVerify = shouldVerify;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslCert(String sslCert) {
+            this.sslCert = sslCert;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslKey(String sslKey) {
+            this.sslKey = sslKey;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslKeyPassphrase(String sslKeyPassphrase) {
+            this.sslKeyPassphrase = sslKeyPassphrase;
+            return this;
+        }
+
+        public SslOptionsBuilder setSslExtraChainCerts(String[] sslExtraChainCerts) {
+            this.sslExtraChainCerts = sslExtraChainCerts;
+            return this;
+        }
+
+        public SslOptions build() {
+            return new SslOptions(this);
+        }
+    }
+
+}


### PR DESCRIPTION
replaces #106 

* includes #106 port of ssl server path to netty
* adds a ruby class that creates SslContext if PKCS#1 keys are used
* refactors travis testing setup to use tarballs instead of compiling logstash

If necessary, the travis refactor can be removed as it's contained in a single commit (578969033850bf364de46863bab277052bbd822f)

The initial commit from #106 was preserved.

fixes #104 