### PR TITLE
Fix heading for `ssl_certificate_authorities` docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -145,7 +145,7 @@ Path to certificate in PEM format. This certificate will be presented
 to the connecting clients.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
-===== `ssl_extra_chain_certs`
+===== `ssl_certificate_authorities`
 
   * Value type is <<array,array>>
   * Default value is `[]`


### PR DESCRIPTION
Doc bug was introduced in #124

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
