### PR TITLE
Explicitly specify fully qualified package to SslContextBuilder

### DIFF
--- a/lib/logstash/inputs/tcp/compat_ssl_options.rb
+++ b/lib/logstash/inputs/tcp/compat_ssl_options.rb
@@ -107,7 +107,9 @@ class SslOptions
         cert_chain << cert
       end
     end
-    sslContextBuilder = SslContextBuilder.forServer(private_key, @ssl_key_passphrase, cert_chain.to_java(X509Certificate))
+
+    # Fully Qualify name of `SslContextBuilder` to avoid picking up the implementation of `SslContextBuilder` from the beats input
+    sslContextBuilder = Java::IoNettyHandlerSsl::SslContextBuilder.forServer(private_key, @ssl_key_passphrase, cert_chain.to_java(X509Certificate))
 
     trust_certs = []
 


### PR DESCRIPTION
Since the release of beats 6.0.8, in certain instances
(multiple pipelines where TCP and beats inputs are defined in
separate pipelines), the TCP input is using
org.logstash.netty.SslContextBuilder defined in the beats input instead
of the desired o.netty.handler.ssl.SslContextBuilder from the Netty library.
This causes TCP pipelines to fail to be created, due to a method missing error