### PR TITLE
remove unnecessary constraint in Gemfile for rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,3 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
-
-if RUBY_VERSION == "1.9.3"
-  gem 'rake', '12.2.1'
-end


### PR DESCRIPTION
we no longer support ruby 1.9 which was last supported in 5.x by using jruby 1.7.x
