### PR TITLE
Extract peer certificate if client is verified

### DIFF
--- a/lib/logstash/inputs/tcp/decoder_impl.rb
+++ b/lib/logstash/inputs/tcp/decoder_impl.rb
@@ -13,7 +13,7 @@ class DecoderImpl
     @first_read = true
   end
 
-  def decode(channel_addr, data)
+  def decode(channel_addr, data, cert_subject = "")
     bytes = Java::byte[data.readableBytes].new
     data.getBytes(0, bytes)
     data.release
@@ -22,7 +22,7 @@ class DecoderImpl
       tbuf = init_first_read(channel_addr, tbuf)
     end
     @tcp.decode_buffer(@ip_address, @address, @port, @codec,
-                       @proxy_address, @proxy_port, tbuf, nil)
+                       @proxy_address, @proxy_port, tbuf, nil, cert_subject)
   end
 
   def copy

--- a/src/main/java/org/logstash/tcp/Decoder.java
+++ b/src/main/java/org/logstash/tcp/Decoder.java
@@ -12,8 +12,9 @@ public interface Decoder {
      * Decode data coming from specific {@link SocketAddress} session.
      * @param key {@link SocketAddress}
      * @param message Data {@link ByteBuf} for this address
+     * @param peerSslCertSubject String The subject of the peer's SSL certificate
      */
-    void decode(SocketAddress key, ByteBuf message);
+    void decode(SocketAddress key, ByteBuf message, String peerSslCertSubject);
 
     /**
      * Creates a copy of this decoder, that has all internal meta data cleared.


### PR DESCRIPTION
Here is a pull request that fix #143. I think it a bit clumsy (I didn't want to rework the full plugin but tried to integrate the changes in the existing code) but it is doing the job on our production (about 2k events/s).