### PR TITLE
DOCTEST: Add a second file in order to test impact

### DIFF
--- a/docs/testfile.asciidoc
+++ b/docs/testfile.asciidoc
@@ -1,0 +1,30 @@
+:plugin: tcp-test
+:type: input
+:default_codec: line
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: %VERSION%
+:release_date: %RELEASE_DATE%
+:changelog_url: %CHANGELOG_URL%
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Tcp input plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This is only a test. 
+
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
+
+:default_codec!:

--- a/docs/testfile.asciidoc
+++ b/docs/testfile.asciidoc
@@ -15,7 +15,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Tcp input plugin
+=== Tcp-test input plugin
 
 include::{include_path}/plugin_header.asciidoc[]
 


### PR DESCRIPTION
Testing to see if we can safely add a second file to the `/docs/` directory without disrupting normal docgen processing. 

Goal: Find the best approach for handling aliased plugins.

Test Plan: 
* Introduce test file (do not include in changelog).
* Bump version and publish gem.
* Generate plugin docs to be sure that extra file doesn't cause problems. Look for any unexpected consequences. 
* Delete testfile. 

@Andsel Perhaps we can work together to run this test when you finalize #169. This could be relevant to other project we're working on together. 