### PR TITLE
Syntax errors in example

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -105,9 +105,9 @@ If an event is missing this metadata, it can be copied into place from the sourc
 [source,txt]
 -----
 filter {
-  if [@metadata][input][tcp][source] and not [host] {
+  if [@metadata][input][tcp][source] and not ([host]) {
     mutate {
-      copy {
+      copy => {
         "[@metadata][input][tcp][source][name]" => "[host][name]"
         "[@metadata][input][tcp][source][ip]"   => "[host][ip]"
       }


### PR DESCRIPTION
There are couple of syntax mistakes in example. "not" expression needs "()" around "[host]" variable and after "copy" must be "=>".

filter {
  if [@metadata][input][tcp][source] and not ([host]) {
    mutate {
      copy => {
        "[@metadata][input][tcp][source][name]" => "[host][name]"
        "[@metadata][input][tcp][source][ip]"   => "[host][ip]"
      }
    }
  }
}

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
