### PR TITLE
Correct link format in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.0.1
-  - Name netty threads with plugin id and their purpose [229](https://github.com/logstash-plugins/logstash-input-tcp/pull/229)
+  - Name netty threads with plugin id and their purpose [#229](https://github.com/logstash-plugins/logstash-input-tcp/pull/229)
 
 ## 7.0.0
   - SSL settings that were marked deprecated in version `6.4.0` are now marked obsolete, and will prevent the plugin from starting.
@@ -7,7 +7,7 @@
     - `ssl_cert`, which should be replaced by `ssl_certificate`
     - `ssl_enable`, which should be replaced by `ssl_enabled`
     - `ssl_verify`, which should be replaced by `ssl_client_authentication` when `mode` is `server` or `ssl_verification_mode`when mode is `client`
-    - [228](https://github.com/logstash-plugins/logstash-input-tcp/pull/228)
+    - [#228](https://github.com/logstash-plugins/logstash-input-tcp/pull/228)
 
 ## 6.4.4
   - update netty to 4.1.115 [#227](https://github.com/logstash-plugins/logstash-input-tcp/pull/227)


### PR DESCRIPTION
Links in changelog must be formatted correctly to appear properly in release notes.

Links in the release notes aren't properly transformed when entries are missing the leading `#` before the PR number. 

<img width="886" alt="Screenshot 2025-02-10 at 10 51 16 AM" src="https://github.com/user-attachments/assets/5957d733-0923-49bd-8edc-01da0db911cd" />


