### PR TITLE
use PortManagementSupport mixin to reserve port in #register

### DIFF
--- a/logstash-input-tcp.gemspec
+++ b/logstash-input-tcp.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
+  s.add_runtime_dependency 'logstash-mixin-port_management_support', '~>1.0'
 
   s.add_runtime_dependency 'logstash-core', '>= 8.1.0'
 

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -21,19 +21,27 @@ require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 #Cabin::Channel.get(LogStash).level = :debug
 describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
 
-  def get_port
-    begin
-      # Start high to better avoid common services
-      port = rand(10000..65535)
-      s = TCPServer.new("127.0.0.1", port)
-      s.close
-      return port
-    rescue Errno::EADDRINUSE
-      retry
-    end
+  ##
+  # yield the block with a port that is available
+  # @return [Integer]: a port that is available
+  def find_available_port
+    with_bound_port(&:itself)
   end
 
-  let(:port) { get_port }
+  ##
+  # Yields block with a port that is unavailable
+  # @yieldparam port [Integer]
+  # @yieldreturn [Object]
+  # @return [Object]
+  def with_bound_port(port=0, &block)
+    server = TCPServer.new("::", port)
+
+    return yield(server.local_address.ip_port)
+  ensure
+    server.close
+  end
+
+  let(:port) { find_available_port }
 
   context "codec (PR #1372)" do
     it "switches from plain to line" do
@@ -371,6 +379,14 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
 
       it "should register without errors" do
         expect { subject.register }.to_not raise_error
+      end
+
+      context "when the port is unavailable" do
+        it 'raises a helpful exception' do
+          with_bound_port(port) do |unavailable_port|
+            expect { subject.register }.to raise_error(Errno::EADDRINUSE)
+          end
+        end
       end
 
       context "when using ssl" do

--- a/src/main/java/org/logstash/tcp/InputLoop.java
+++ b/src/main/java/org/logstash/tcp/InputLoop.java
@@ -93,7 +93,7 @@ public final class InputLoop implements Closeable {
         }
         try {
             channel = serverBootstrap.bind(host, port).sync().channel();
-        }catch (final InterruptedException ex) {
+        } catch (final InterruptedException ex) {
             throw new IllegalStateException(ex);
         }
     }
@@ -101,7 +101,7 @@ public final class InputLoop implements Closeable {
     public void waitUntilClosed() {
         synchronized (this) {
             if (channel == null) {
-                throw new IllegalStateException("not started");
+                throw new IllegalStateException("Not started");
             }
         }
         try {


### PR DESCRIPTION
Uses the `PortManagementSupport` mixin from https://github.com/logstash-plugins/logstash-mixin-port_management_support/pull/1 to reserve a port in `#register` so that the plugin will fail to start if the port is unavailable.

Resolves the TCP input's expression of https://github.com/elastic/logstash/issues/17703