### PR TITLE
Stop filtering stack version 7 from default matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,2 @@
 import:
 - logstash-plugins/.ci:travis/travis.yml@1.x
-
-jobs:
-  exclude:
-  - env: ELASTIC_STACK_VERSION=7.current
-  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=7.current


### PR DESCRIPTION
Removed with logstash-plugins/.ci#106

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
