### PR TITLE
Aggregate HA proxy line before parsing it

### DIFF
--- a/lib/logstash/inputs/tcp.rb
+++ b/lib/logstash/inputs/tcp.rb
@@ -179,7 +179,8 @@ class LogStash::Inputs::Tcp < LogStash::Inputs::Base
     if server?
       begin
         @logger.info("Binding tcp input listener", :address => "#{@host}:#{@port}", :ssl_enabled => @ssl_enabled)
-        @loop = InputLoop.new(@id, @host, @port, DecoderImpl.new(@codec, self), @tcp_keep_alive, java_ssl_context)
+        @loop = InputLoop.new(@id, @host, @port, DecoderImpl.new(@codec, self), @tcp_keep_alive, java_ssl_context, 
+                              @proxy_protocol)
       rescue java.net.BindException => bind_exception
         fail LogStash::ConfigurationError, "could not bind to #{@host}:#{@port}; #{bind_exception.message}"
       end

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -42,7 +42,8 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
   end
 
   def queue_pop_with_timeout(seconds, queue)
-    deadline = Time.now + seconds
+    start = Time.now
+    deadline = start + seconds
     item = nil
     until item || Time.now >= deadline
       begin
@@ -50,6 +51,9 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
       rescue ThreadError
         sleep 0.1
       end
+    end
+    if item == nil
+      raise "Elapsed #{Time.now - start} seconds before pop a value"
     end
     return item
   end

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -41,6 +41,19 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
     server.close
   end
 
+  def queue_pop_with_timeout(seconds, queue)
+    deadline = Time.now + seconds
+    item = nil
+    until item || Time.now >= deadline
+      begin
+        item = queue.pop(true)   # raises ThreadError if empty
+      rescue ThreadError
+        sleep 0.1
+      end
+    end
+    return item
+  end
+
   let(:port) { find_available_port("127.0.0.1") }
 
   context "codec (PR #1372)" do
@@ -139,15 +152,23 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
         socket = Stud::try(5.times) { TCPSocket.new("127.0.0.1", port) }
         socket.write("PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678\r")
         socket.flush
-        socket.write("\n")
-        event_count.times do |i|
-          # unicode smiley for testing unicode support!
-          socket.puts("#{i} ☹")
-          socket.flush
+        # proceed with the rest of data writing in a separate thread
+        # so that crates some interleaving in the buffers seen on network layer
+        Thread.new do
+          sleep(1)
+          begin
+            socket.write("\n")
+            event_count.times do |i|
+              # unicode smiley for testing unicode support!
+              socket.puts("#{i} ☹")
+              socket.flush
+            end
+            socket.close
+          rescue => e
+            puts "Error while writing to the socket #{e.backtrace}"
+          end
         end
-        socket.close
-
-        event_count.times.collect {queue.pop}
+        event_count.times.collect { queue_pop_with_timeout(5, queue) }
       end
 
       expect(events.length).to eq(event_count)
@@ -675,6 +696,7 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
       context "when ssl_enabled is true" do
         let(:input) { subject }
         let(:queue) { Queue.new }
+        # let(:queue) { Thread::Queue.new }
         before(:each) do
           allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility) if defined?(ecs_compatibility)
           subject.register

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -700,7 +700,6 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
       context "when ssl_enabled is true" do
         let(:input) { subject }
         let(:queue) { Queue.new }
-        # let(:queue) { Thread::Queue.new }
         before(:each) do
           allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility) if defined?(ecs_compatibility)
           subject.register

--- a/spec/inputs/tcp_spec.rb
+++ b/spec/inputs/tcp_spec.rb
@@ -135,10 +135,11 @@ describe LogStash::Inputs::Tcp, :ecs_compatibility_support do
         }
       CONFIG
 
-      events = input(conf) do |pipeline, queue|
+      events = input(conf) do |_, queue|
         socket = Stud::try(5.times) { TCPSocket.new("127.0.0.1", port) }
-        socket.puts("PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678\r");
+        socket.write("PROXY TCP4 1.2.3.4 5.6.7.8 1234 5678\r")
         socket.flush
+        socket.write("\n")
         event_count.times do |i|
           # unicode smiley for testing unicode support!
           socket.puts("#{i} ☹")

--- a/src/main/java/org/logstash/tcp/InputLoop.java
+++ b/src/main/java/org/logstash/tcp/InputLoop.java
@@ -69,7 +69,7 @@ public final class InputLoop implements Runnable, Closeable {
      * @param keepAlive set to true to instruct the socket to issue TCP keep alive
      */
     public InputLoop(final String id, final String host, final int port, final Decoder decoder, final boolean keepAlive,
-                     final SslContext sslContext) {
+                     final SslContext sslContext, final boolean proxy) {
         this.sslContext = sslContext;
         this.host = host;
         this.port = port;
@@ -80,7 +80,7 @@ public final class InputLoop implements Runnable, Closeable {
             .option(ChannelOption.SO_BACKLOG, 1024)
             .option(ChannelOption.AUTO_READ, false) // do not auto-read until plugin has a queue
             .childOption(ChannelOption.SO_KEEPALIVE, keepAlive)
-            .childHandler(new InputLoop.InputHandler(decoder, sslContext));
+            .childHandler(new InputLoop.InputHandler(decoder, sslContext, proxy));
 
         try {
             serverChannel = serverBootstrap.bind(host, port).sync().channel();
@@ -131,14 +131,16 @@ public final class InputLoop implements Runnable, Closeable {
          * SSL configuration options.
          */
         private final SslContext sslContext;
+        private final boolean proxy;
 
         /**
          * Ctor.
          * @param decoder {@link Decoder} provided by JRuby.
          */
-        InputHandler(final Decoder decoder, final SslContext sslContext) {
+        InputHandler(final Decoder decoder, final SslContext sslContext, final boolean proxy) {
             this.decoder = decoder;
             this.sslContext = sslContext;
+            this.proxy = proxy;
         }
 
         @Override
@@ -150,6 +152,9 @@ public final class InputLoop implements Runnable, Closeable {
                 channel.pipeline().addLast(SSL_HANDLER, sslContext.newHandler(channel.alloc()));
             }
 
+            if (proxy) {
+                channel.pipeline().addLast(new ProxyLineAggregator());
+            }
             channel.pipeline().addLast(new DecoderAdapter(localCopy, logger));
             channel.closeFuture().addListener(new FlushOnCloseListener(localCopy));
 

--- a/src/main/java/org/logstash/tcp/InputLoop.java
+++ b/src/main/java/org/logstash/tcp/InputLoop.java
@@ -67,6 +67,8 @@ public final class InputLoop implements Runnable, Closeable {
      * @param port Port to listen on
      * @param decoder {@link Decoder} provided by Jruby
      * @param keepAlive set to true to instruct the socket to issue TCP keep alive
+     * @param sslContext SSL configuration, or null when TLS is disabled
+     * @param proxy set to true to aggregate the HAProxy v1 header line before decoding
      */
     public InputLoop(final String id, final String host, final int port, final Decoder decoder, final boolean keepAlive,
                      final SslContext sslContext, final boolean proxy) {

--- a/src/main/java/org/logstash/tcp/ProxyLineAggregator.java
+++ b/src/main/java/org/logstash/tcp/ProxyLineAggregator.java
@@ -1,0 +1,64 @@
+package org.logstash.tcp;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.util.ByteProcessor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+
+/**
+ * Accumulate bytes until the HAProxy format v1 headline is present in the buffer.
+ * The line has format "PROXY....\r\n", this aggregator reject the buffer until it has that format,
+ * once reached passthrough every buffer as it is.
+ * This is needed because Ruby class DecoderImpl expect to have the full line when processing HAProxy protocol, and
+ * doesn't work with fragments.
+ * */
+public class ProxyLineAggregator extends ByteToMessageDecoder {
+
+    private static final byte[] PROXY_PREFIX = "PROXY".getBytes(StandardCharsets.US_ASCII);
+    public static final int PROXY_LENGTH = PROXY_PREFIX.length;
+
+    enum DecoderState {READ_PROXY, COMPLETED}
+
+    private DecoderState state;
+
+    public ProxyLineAggregator() {
+        this.state = DecoderState.READ_PROXY;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
+        switch (state) {
+            case READ_PROXY:
+                if (buffer.readableBytes() < PROXY_LENGTH) {
+                    return;
+                }
+                if (!startsWithProxy(buffer)) {
+                    state = DecoderState.COMPLETED;
+                    out.add(buffer.readRetainedSlice(buffer.readableBytes()));
+                    return;
+                }
+                if (buffer.forEachByte(ByteProcessor.FIND_CRLF) == -1) {
+                    return;
+                }
+                state = DecoderState.COMPLETED;
+                out.add(buffer.readRetainedSlice(buffer.readableBytes()));
+                break;
+            case COMPLETED:
+                out.add(buffer.readRetainedSlice(buffer.readableBytes()));
+                break;
+        }
+    }
+
+    private static boolean startsWithProxy(ByteBuf buffer) {
+        for (int i = 0; i < PROXY_LENGTH; i++) {
+            if (buffer.getByte(buffer.readerIndex() + i) != PROXY_PREFIX[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/logstash/tcp/ProxyLineAggregator.java
+++ b/src/main/java/org/logstash/tcp/ProxyLineAggregator.java
@@ -41,7 +41,7 @@ public class ProxyLineAggregator extends ByteToMessageDecoder {
                     out.add(buffer.readRetainedSlice(buffer.readableBytes()));
                     return;
                 }
-                if (buffer.forEachByte(ByteProcessor.FIND_CRLF) == -1) {
+                if (!containsCrlf(buffer)) {
                     return;
                 }
                 state = DecoderState.COMPLETED;
@@ -51,6 +51,11 @@ public class ProxyLineAggregator extends ByteToMessageDecoder {
                 out.add(buffer.readRetainedSlice(buffer.readableBytes()));
                 break;
         }
+    }
+
+    private static boolean containsCrlf(ByteBuf buffer) {
+        int lfIndex = buffer.forEachByte(ByteProcessor.FIND_LF);
+        return lfIndex > 0 && buffer.getByte(lfIndex - 1) == '\r';
     }
 
     private static boolean startsWithProxy(ByteBuf buffer) {

--- a/src/main/java/org/logstash/tcp/ProxyLineAggregator.java
+++ b/src/main/java/org/logstash/tcp/ProxyLineAggregator.java
@@ -10,47 +10,30 @@ import java.util.List;
 
 
 /**
- * Accumulate bytes until the HAProxy format v1 headline is present in the buffer.
- * The line has format "PROXY....\r\n", this aggregator reject the buffer until it has that format,
- * once reached passthrough every buffer as it is.
- * This is needed because Ruby class DecoderImpl expect to have the full line when processing HAProxy protocol, and
- * doesn't work with fragments.
+ * The line has format "PROXY....\r\n"; this aggregator holds back the buffer until that full
+ * line is available, then passes it through and removes itself from the pipeline.
+ * This is needed because Ruby class DecoderImpl expects the full line when processing the HAProxy
+ * protocol and doesn't work with fragments.
  * */
 public class ProxyLineAggregator extends ByteToMessageDecoder {
 
     private static final byte[] PROXY_PREFIX = "PROXY".getBytes(StandardCharsets.US_ASCII);
     public static final int PROXY_LENGTH = PROXY_PREFIX.length;
 
-    enum DecoderState {READ_PROXY, COMPLETED}
-
-    private DecoderState state;
-
-    public ProxyLineAggregator() {
-        this.state = DecoderState.READ_PROXY;
-    }
-
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
-        switch (state) {
-            case READ_PROXY:
-                if (buffer.readableBytes() < PROXY_LENGTH) {
-                    return;
-                }
-                if (!startsWithProxy(buffer)) {
-                    state = DecoderState.COMPLETED;
-                    out.add(buffer.readRetainedSlice(buffer.readableBytes()));
-                    return;
-                }
-                if (!containsCrlf(buffer)) {
-                    return;
-                }
-                state = DecoderState.COMPLETED;
-                out.add(buffer.readRetainedSlice(buffer.readableBytes()));
-                break;
-            case COMPLETED:
-                out.add(buffer.readRetainedSlice(buffer.readableBytes()));
-                break;
+        // Wait until we can decide: enough bytes to match the prefix, and if it is a PROXY
+        // line, the terminating \r\n must be present.
+        if (buffer.readableBytes() < PROXY_LENGTH) {
+            return;
         }
+        if (startsWithProxy(buffer) && !containsCrlf(buffer)) {
+            return;
+        }
+        // Full PROXY line, or non-PROXY data: pass everything through and drop this handler
+        // so subsequent reads skip the aggregator entirely.
+        out.add(buffer.readRetainedSlice(buffer.readableBytes()));
+        ctx.pipeline().remove(this);
     }
 
     private static boolean containsCrlf(ByteBuf buffer) {

--- a/src/test/java/org/logstash/tcp/ProxyLineAggregatorTest.java
+++ b/src/test/java/org/logstash/tcp/ProxyLineAggregatorTest.java
@@ -1,0 +1,65 @@
+package org.logstash.tcp;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class ProxyLineAggregatorTest {
+
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel(new ProxyLineAggregator());
+    }
+
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
+    }
+
+    private static ByteBuf ascii(String s) {
+        return Unpooled.copiedBuffer(s, StandardCharsets.US_ASCII);
+    }
+
+    @Test
+    void partialProxyHeader_producesNoOutput() {
+        // "PRO" is shorter than the 5-byte "PROXY" prefix — decoder must wait
+        channel.writeInbound(ascii("PRO"));
+        assertThat(channel.readInbound(), nullValue());
+    }
+
+    @Test
+    void proxyPrefixWithoutCRLF_producesNoOutput() {
+        // Full PROXY keyword is present but the line terminator \r\n is missing
+        channel.writeInbound(ascii("PROXY TCP4 192.168.1.1 10.0.0.1 1234 80"));
+        assertThat(channel.readInbound(), nullValue());
+    }
+
+    @Test
+    void nonProxyDataWithSufficientBytes_passesThrough() {
+        // Content >= PROXY_LENGTH bytes but not a PROXY header and no \r\n:
+        // the aggregator should recognise it is not a PROXY line and let it through
+        channel.writeInbound(ascii("Hello, World!"));
+        ByteBuf result = channel.readInbound();
+        assertThat(result, notNullValue());
+        result.release();
+    }
+
+    @Test
+    void completeProxyLineWithCRLF_forwardsBuffer() {
+        channel.writeInbound(ascii("PROXY TCP4 192.168.1.1 10.0.0.1 1234 80\r\n"));
+        ByteBuf result = channel.readInbound();
+        assertThat(result, notNullValue());
+        result.release();
+    }
+}


### PR DESCRIPTION
## Release notes
Fix for processing the HA Proxy protocol, considering the line can be splitted in multiple buffers.


## What does this PR do?
Adds an aggregator to collect all the bytes up to the first newline before move on to the decoding part done by DecoderImpl class. This message decoder is added only if proxy setting is enabled.


## Why is it important/What is the impact to the user?
Avoids error that could rise if the TCP stack decides to break the HA Proxy v1 headline before the newline terminator in multiple byte arrays.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
-  Closes #285 
